### PR TITLE
Base.LinAlg.BLAS integration.

### DIFF
--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -8,11 +8,12 @@
 #
 
 module CUBLAS
+importall Base.LinAlg.BLAS
 
 using CUDArt
 #using CUDArt.CudaPtr
 
-import Base.LinAlg.BlasChar
+typealias BlasChar Char #import Base.LinAlg.BlasChar
 import Base.one
 import Base.zero
 


### PR DESCRIPTION
importall BLAS so we can write generic code.
BlasChar no longer defined in v0.4, so provided a definition as workaround.
