### PR TITLE
RFC: Batched CUBLAS functions

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -1493,7 +1493,7 @@ for (fname, elty) in
                 push!(TauArray,CudaArray(hTauArray[i]))
             end
             Tauptrs = CudaArray(map( (x) -> pointer(x).ptr, TauArray ))
-            info    = 0
+            info    = zero(Cint)
             statuscheck(ccall(($(string(fname)),libcublas), cublasStatus_t,
                               (cublasHandle_t, Cint, Cint, Ptr{Ptr{$elty}},
                               Cint, Ptr{Ptr{$elty}}, Ptr{Cint}, Cint),
@@ -1546,8 +1546,8 @@ for (fname, elty) in
             ldc = max(1,stride(A[1],2))
             Aptrs = CudaArray(map((x) -> pointer(x).ptr, A ))
             Cptrs = CudaArray(map((x) -> pointer(x).ptr, C ))
-            info = 0
-            infoarray    = C_NULL #CudaArray(zeros(Cint, length(A)))
+            info  = zero(Cint)
+            infoarray = CudaArray(zeros(Cint, length(A)))
             statuscheck(ccall(($(string(fname)),libcublas), cublasStatus_t,
                               (cublasHandle_t, cublasOperation_t, Cint, Cint,
                               Cint, Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}},

--- a/src/blas.jl
+++ b/src/blas.jl
@@ -807,6 +807,74 @@ for (fname, elty) in
     end
 end
 
+## (GE) general matrix-matrix multiplication batched
+for (fname, elty) in
+        ((:cublasDgemmBatched,:Float64),
+         (:cublasSgemmBatched,:Float32),
+         (:cublasZgemmBatched,:Complex128),
+         (:cublasCgemmBatched,:Complex64))
+    @eval begin
+        # cublasStatus_t cublasDgemmBatched(
+        #   cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb,
+        #   int m, int n, int k,
+        #   const double *alpha, const double **A, int lda,
+        #   const double **B, int ldb, const double *beta,
+        #   double **C, int ldc, int batchCount)
+        function gemm_batched!(transA::BlasChar,
+                               transB::BlasChar,
+                               alpha::($elty),
+                               A::Array{CudaMatrix{$elty},1},
+                               B::Array{CudaMatrix{$elty},1},
+                               beta::($elty),
+                               C::Array{CudaMatrix{$elty},1})
+            if( length(A) != length(B) || length(A) != length(C) )
+                throw(DimensionMismatch(""))
+            end
+            for (As,Bs,Cs) in zip(A,B,C)
+                m = size(As, transA == 'N' ? 1 : 2)
+                k = size(As, transA == 'N' ? 2 : 1)
+                n = size(Bs, transB == 'N' ? 2 : 1)
+                if m != size(Cs,1) || n != size(Cs,2) || k != size(Bs, transB == 'N' ? 1 : 2)
+                    throw(DimensionMismatch(""))
+                end
+            end
+            m = size(A[1], transA == 'N' ? 1 : 2)
+            k = size(A[1], transA == 'N' ? 2 : 1)
+            n = size(B[1], transB == 'N' ? 2 : 1)
+            cutransA = cublasop(transA)
+            cutransB = cublasop(transB)
+            lda = max(1,stride(A[1],2))
+            ldb = max(1,stride(B[1],2))
+            ldc = max(1,stride(C[1],2))
+            Aptrs = CudaArray(map( (x) -> pointer(x).ptr, A ))
+            Bptrs = CudaArray(map( (x) -> pointer(x).ptr, B ))
+            Cptrs = CudaArray(map( (x) -> pointer(x).ptr, C ))
+            statuscheck(ccall(($(string(fname)),libcublas), cublasStatus_t,
+                              (cublasHandle_t, cublasOperation_t,
+                              cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
+                              Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}}, Cint, Ptr{$elty},
+                              Ptr{Ptr{$elty}}, Cint, Cint), cublashandle[1], cutransA,
+                              cutransB, m, n, k, [alpha], Aptrs, lda, Bptrs, ldb, [beta],
+                              Cptrs, ldc, length(A)))
+            C
+        end
+        function gemm_batched(transA::BlasChar,
+                      transB::BlasChar,
+                      alpha::($elty),
+                      A::Array{CudaMatrix{$elty},1},
+                      B::Array{CudaMatrix{$elty},1})
+            C = CudaMatrix{$elty}[similar( B[1], $elty, (size(A[1], transA == 'N' ? 1 : 2),size(B[1], transB == 'N' ? 2 : 1))) for i in 1:length(A)]
+            gemm_batched!(transA, transB, alpha, A, B, zero($elty), C )
+        end
+        function gemm_batched(transA::BlasChar,
+                      transB::BlasChar,
+                      A::Array{CudaMatrix{$elty},1},
+                      B::Array{CudaMatrix{$elty},1})
+            gemm_batched(transA, transB, one($elty), A, B)
+        end
+    end
+end
+
 ## (SY) symmetric matrix-matrix and matrix-vector multiplication
 for (fname, elty) in ((:cublasDsymm_v2,:Float64),
                       (:cublasSsymm_v2,:Float32),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1439,3 +1439,27 @@ test_getri_batched(Float32)
 test_getri_batched(Float64)
 test_getri_batched(Complex64)
 test_getri_batched(Complex128)
+
+#######################
+# test matinv_batched #
+#######################
+
+function test_matinv_batched(elty)
+    # generate matrices
+    A = [rand(elty,m,m) for i in 1:10]
+    # move to device
+    d_A = CudaArray{elty, 2}[]
+    for i in 1:length(A)
+        push!(d_A,CudaArray(A[i]))
+    end
+    info, d_C = CUBLAS.matinv_batched(d_A)
+    for Cs in 1:length(d_C)
+        C   = inv(A[Cs])
+        h_C = to_host(d_C[Cs])
+        @test_approx_eq(C,h_C)
+    end
+end
+test_matinv_batched(Float32)
+test_matinv_batched(Float64)
+test_matinv_batched(Complex64)
+test_matinv_batched(Complex128)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1525,3 +1525,53 @@ test_geqrf_batched(Float32)
 test_geqrf_batched(Float64)
 test_geqrf_batched(Complex64)
 test_geqrf_batched(Complex128)
+
+#####################
+# test gels_batched #
+#####################
+
+function test_gels_batched!(elty)
+    # generate matrices
+    A = [rand(elty,n,n) for i in 1:10]
+    C = [rand(elty,n,k) for i in 1:10]
+    # move to device
+    d_A = CudaArray{elty, 2}[]
+    d_C = CudaArray{elty, 2}[]
+    for i in 1:length(A)
+        push!(d_A,CudaArray(A[i]))
+        push!(d_C,CudaArray(C[i]))
+    end
+    d_A, d_C, info = CUBLAS.gels_batched!('N',d_A, d_C)
+    for Cs in 1:length(d_C)
+        X = A[Cs]\C[Cs]
+        h_C = to_host(d_C[Cs])
+        @test_approx_eq(X,h_C)
+    end
+end
+test_gels_batched!(Float32)
+test_gels_batched!(Float64)
+test_gels_batched!(Complex64)
+test_gels_batched!(Complex128)
+
+function test_gels_batched(elty)
+    # generate matrices
+    A = [rand(elty,n,n) for i in 1:10]
+    C = [rand(elty,n,k) for i in 1:10]
+    # move to device
+    d_A = CudaArray{elty, 2}[]
+    d_C = CudaArray{elty, 2}[]
+    for i in 1:length(A)
+        push!(d_A,CudaArray(A[i]))
+        push!(d_C,CudaArray(C[i]))
+    end
+    d_B, d_D, info = CUBLAS.gels_batched('N',d_A, d_C)
+    for Ds in 1:length(d_D)
+        X = A[Ds]\C[Ds]
+        h_D = to_host(d_D[Ds])
+        @test_approx_eq(X,h_D)
+    end
+end
+test_gels_batched(Float32)
+test_gels_batched(Float64)
+test_gels_batched(Complex64)
+test_gels_batched(Complex128)


### PR DESCRIPTION
I have implemented the wrappers and written passing tests for all of the batched CUDA 6.5 CUBLAS functions. I was branching out on my own here a bit so this PR is RFC because I want to make sure it's consistent with the current coding style. I'm happy to do cleanups/add more tests.

In particular, this PR adds:
- `gemmBatched`
- `trsmBatched`
- `getrfBatched`
- `getriBatched`
- `matinvBatched`
- `geqrfBatched`
- `gelsBatched`
