### PR TITLE
Proposed fix on finding CUBLAS lib on Windows.

### DIFF
--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -72,7 +72,15 @@ function statuscheck(status)
 end
 
 # find the cublas library
-const libcublas = Libdl.find_library(["libcublas"], ["/usr/local/cuda"])
+@windows? (
+begin
+    const libcublas = Libdl.find_library(["cublas64_75"], [""])
+end
+: 
+begin
+    const libcublas = Libdl.find_library(["libcublas"], ["/usr/local/cuda"])
+end)
+
 if isempty(libcublas)
     error("CUBLAS library cannot be found")
 end


### PR DESCRIPTION
Hello,

I have found an issue running CUBLAS on windows using your lib. The file libcuda is called cublas64_75. It requires the user to have CUDA 7.5 installed. 

We should find a way to abstract the version in the name of the dll.

Hope that helps,
