### PR TITLE
Allow switching devices. Use `__init__`.

### DIFF
--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -82,13 +82,15 @@ include("libcublas.jl")
 # Global CUBLAS handle used for higher-level BLAS functions.
 const cublashandle = cublasHandle_t[C_NULL]
 
-function use_current_device()
+function destroy()
     if cublashandle[1] != C_NULL
         cublasDestroy_v2(cublashandle[1])
         cublashandle[1] = C_NULL
     end
+end
 
-    # setup cublas handle
+function use_current_device()
+    destroy()
     cublasCreate_v2(cublashandle)
 end
 
@@ -96,12 +98,7 @@ include("blas.jl")
 
 function __init__()
     use_current_device()
-    atexit(()->
-        if cublashandle[1] != C_NULL
-            cublasDestroy_v2(cublashandle[1])
-            cublashandle[1] = C_NULL
-        end
-    )
+    atexit(destroy)
 end
 
 end # module


### PR DESCRIPTION
This introduces the `use_current_device` function which initializes CUBLAS for the currently active device, thus allowing the use of `blas.jl` functions on non-default GPU.

In addition, move initialization (and registration of the finalizer) into `__init__` so that we can make use of pre-compilation in the future.

The default behavior should be unchanged by this.
