### PR TITLE
don't try to free resources atexit

### DIFF
--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -81,8 +81,6 @@ include("libcublas.jl")
 # setup cublas handle
 cublashandle = cublasHandle_t[0]
 cublasCreate_v2(cublashandle)
-# destroy cublas handle at julia exit
-atexit(()->cublasDestroy_v2(cublashandle[1]))
 
 include("blas.jl")
 


### PR DESCRIPTION
cublas.jl tries to clean up resources in an atexit handler.  If cudart is closed by the user before the process terminates, then this will create problems.

It's good to clean up resources when you're done with them, but the operating system (or cuda driver) will free them for you when the process terminates.

I suspect that the global cublas handle will become a larger problem later and something like cudart.jl's with device do block syntax with automatic cleanup will be required.  Until then, as long as there's a global cublas handle, it's probably best to hang on to it (or let the user explicitly destroy it) until the process is cleaned up by the operating system.
