### PR TITLE
use Defer instead of atexit

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
+julia 0.4-
 Compat
 CUDArt
-julia 0.4-
+Defer

--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -83,7 +83,7 @@ end
 include("libcublas.jl")
 
 # setup cublas handle
-cublashandle = cublasHandle_t[0]
+const cublashandle = cublasHandle_t[0]
 function __init__()
   cublasCreate_v2(cublashandle)
   # destroy cublas handle at the end of this scope

--- a/src/CUBLAS.jl
+++ b/src/CUBLAS.jl
@@ -9,6 +9,9 @@
 
 module CUBLAS
 using Compat
+using Defer
+
+importall Base.LinAlg
 importall Base.LinAlg.BLAS
 
 using CUDArt
@@ -81,9 +84,11 @@ include("libcublas.jl")
 
 # setup cublas handle
 cublashandle = cublasHandle_t[0]
-cublasCreate_v2(cublashandle)
-# destroy cublas handle at julia exit
-atexit(()->cublasDestroy_v2(cublashandle[1]))
+function __init__()
+  cublasCreate_v2(cublashandle)
+  # destroy cublas handle at the end of this scope
+  @defer cublasDestroy_v2(cublashandle[1])
+end
 
 include("blas.jl")
 include("highlevel.jl")


### PR DESCRIPTION
I previously proposed not closing the cublas handle in an atexit handler (#19).  This PR is for the same reasons but proposes an alternate mechanism to see the handle is closed if and when desired by the user.  It also partially addressed #15.