### PR TITLE
Adding wrapper functions to half precision (FP16) and cublas****Ex() functions.

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -884,6 +884,7 @@ end
 for (fname, elty) in
         ((:cublasDgemm_v2,:Float64),
          (:cublasSgemm_v2,:Float32),
+         (:cublasHgemm, :Float16)
          (:cublasZgemm_v2,:Complex128),
          (:cublasCgemm_v2,:Complex64))
     @eval begin

--- a/src/blas.jl
+++ b/src/blas.jl
@@ -884,7 +884,7 @@ end
 for (fname, elty) in
         ((:cublasDgemm_v2,:Float64),
          (:cublasSgemm_v2,:Float32),
-         (:cublasHgemm, :Float16)
+         (:cublasHgemm, :Float16),
          (:cublasZgemm_v2,:Complex128),
          (:cublasCgemm_v2,:Complex64))
     @eval begin

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -674,3 +674,95 @@ end
 function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
+
+# Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
+function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
+    statuscheck(ccall((:cublasNrm2Ex, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, result, resultType, executionType));
+end
+function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+    statuscheck(ccall((:cublasDotEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+end
+function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+    statuscheck(ccall((:cublasDotcEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+end
+function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
+    statuscheck(ccall((:cublasScalEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                        handle, n, alpha, alphaType, x, xType, incx, executionType));
+end
+function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
+    statuscheck(ccall((:cublasAxpyEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                        handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
+end
+function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCgemm3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasSgemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+    statuscheck(ccall((:cublasGemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCgemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCsyrkEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCherkEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCherk3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+# Wrap FP16 functions (CUDA 7.5+)
+function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    statuscheck(ccall((:cublasHgemm, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
+end
+function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+    statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+end

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -675,97 +675,102 @@ function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
 
-if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
-    # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
-    function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
-        statuscheck(ccall((:cublasNrm2Ex, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                            handle, n, x, xType, incx, result, resultType, executionType));
+try
+    if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
+        # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
+        function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
+            statuscheck(ccall((:cublasNrm2Ex, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, result, resultType, executionType));
+        end
+        function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+            statuscheck(ccall((:cublasDotEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+        end
+        function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+            statuscheck(ccall((:cublasDotcEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+        end
+        function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
+            statuscheck(ccall((:cublasScalEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                                handle, n, alpha, alphaType, x, xType, incx, executionType));
+        end
+        function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
+            statuscheck(ccall((:cublasAxpyEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                                handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
+        end
+        function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCgemm3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasSgemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+            statuscheck(ccall((:cublasGemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+        end
+        function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCgemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCsyrkEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCherkEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCherk3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        # Wrap FP16 functions (CUDA 7.5+)
+        function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+            statuscheck(ccall((:cublasHgemm, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
+        end
+        function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+            statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+        end
     end
-    function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-        statuscheck(ccall((:cublasDotEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                            handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-    end
-    function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-        statuscheck(ccall((:cublasDotcEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                            handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-    end
-    function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
-        statuscheck(ccall((:cublasScalEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                            handle, n, alpha, alphaType, x, xType, incx, executionType));
-    end
-    function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
-        statuscheck(ccall((:cublasAxpyEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                            handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
-    end
-    function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCgemm3mEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-    end
-    function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasSgemmEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-    end
-    function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
-        statuscheck(ccall((:cublasGemmEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
-                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
-    end
-    function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCgemmEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-    end
-    function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCsyrkEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-    end
-    function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-    end
-    function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCherkEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-    end
-    function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-        statuscheck(ccall((:cublasCherk3mEx, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-    end
-    # Wrap FP16 functions (CUDA 7.5+)
-    function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-        statuscheck(ccall((:cublasHgemm, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
-                            handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
-    end
-    function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
-        statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
-                            cublasStatus_t,
-                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
-                            handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
-    end
+catch exception
+    Base.show_backtrace(STDOUT, backtrace());
+    println();
 end

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -723,6 +723,7 @@ function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, 
                         cublasStatus_t,
                         (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
                         handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+end
 function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
     statuscheck(ccall((:cublasCgemmEx, libcublas),
                         cublasStatus_t,

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -675,95 +675,97 @@ function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
 
-# Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
-function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
-    statuscheck(ccall((:cublasNrm2Ex, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, result, resultType, executionType));
-end
-function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-    statuscheck(ccall((:cublasDotEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-end
-function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-    statuscheck(ccall((:cublasDotcEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-end
-function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
-    statuscheck(ccall((:cublasScalEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                        handle, n, alpha, alphaType, x, xType, incx, executionType));
-end
-function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
-    statuscheck(ccall((:cublasAxpyEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                        handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
-end
-function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCgemm3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasSgemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
-    statuscheck(ccall((:cublasGemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
-end
-function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCgemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCsyrkEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCherkEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCherk3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-# Wrap FP16 functions (CUDA 7.5+)
-function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-    statuscheck(ccall((:cublasHgemm, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
-end
-function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
-    statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
+    # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
+    function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
+        statuscheck(ccall((:cublasNrm2Ex, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                            handle, n, x, xType, incx, result, resultType, executionType));
+    end
+    function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+        statuscheck(ccall((:cublasDotEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                            handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+    end
+    function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+        statuscheck(ccall((:cublasDotcEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                            handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+    end
+    function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
+        statuscheck(ccall((:cublasScalEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                            handle, n, alpha, alphaType, x, xType, incx, executionType));
+    end
+    function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
+        statuscheck(ccall((:cublasAxpyEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                            handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
+    end
+    function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCgemm3mEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+    end
+    function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasSgemmEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+    end
+    function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+        statuscheck(ccall((:cublasGemmEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
+                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+    end
+    function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCgemmEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+    end
+    function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCsyrkEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+    end
+    function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+    end
+    function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCherkEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+    end
+    function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+        statuscheck(ccall((:cublasCherk3mEx, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                            handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+    end
+    # Wrap FP16 functions (CUDA 7.5+)
+    function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+        statuscheck(ccall((:cublasHgemm, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                            handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
+    end
+    function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+        statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
+                            cublasStatus_t,
+                            (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                            handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+    end
 end

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -675,95 +675,102 @@ function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
 
-# Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
-function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
-    statuscheck(ccall((:cublasNrm2Ex, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, result, resultType, executionType));
-end
-function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-    statuscheck(ccall((:cublasDotEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-end
-function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-    statuscheck(ccall((:cublasDotcEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-end
-function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
-    statuscheck(ccall((:cublasScalEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                        handle, n, alpha, alphaType, x, xType, incx, executionType));
-end
-function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
-    statuscheck(ccall((:cublasAxpyEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                        handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
-end
-function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCgemm3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasSgemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
-    statuscheck(ccall((:cublasGemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
-end
-function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCgemmEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-end
-function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCsyrkEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCherkEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-    statuscheck(ccall((:cublasCherk3mEx, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-end
-# Wrap FP16 functions (CUDA 7.5+)
-function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-    statuscheck(ccall((:cublasHgemm, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
-end
-function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
-    statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
-                        cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
-                        handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+try
+    if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
+        # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
+        function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
+            statuscheck(ccall((:cublasNrm2Ex, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, result, resultType, executionType));
+        end
+        function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+            statuscheck(ccall((:cublasDotEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+        end
+        function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+            statuscheck(ccall((:cublasDotcEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+        end
+        function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
+            statuscheck(ccall((:cublasScalEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                                handle, n, alpha, alphaType, x, xType, incx, executionType));
+        end
+        function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
+            statuscheck(ccall((:cublasAxpyEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                                handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
+        end
+        function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCgemm3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasSgemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+            statuscheck(ccall((:cublasGemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+        end
+        function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCgemmEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+        end
+        function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCsyrkEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCherkEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+            statuscheck(ccall((:cublasCherk3mEx, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+        end
+        # Wrap FP16 functions (CUDA 7.5+)
+        function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+            statuscheck(ccall((:cublasHgemm, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
+        end
+        function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+            statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
+                                cublasStatus_t,
+                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                                handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
+        end
+    end
+catch exception
+    Base.show_backtrace(STDOUT, backtrace());
+    println();
 end

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -675,6 +675,7 @@ function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
 
+using CUDArt;
 try
     if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
         # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)

--- a/src/libcublas.jl
+++ b/src/libcublas.jl
@@ -675,103 +675,95 @@ function cublasZtrttp(handle, uplo, n, A, lda, AP)
   statuscheck(ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP))
 end
 
-using CUDArt;
-try
-    if (CUDArt.runtime_version() >= 7500)   #these functions were introduced with CUDA v7.5
-        # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
-        function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
-            statuscheck(ccall((:cublasNrm2Ex, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                                handle, n, x, xType, incx, result, resultType, executionType));
-        end
-        function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-            statuscheck(ccall((:cublasDotEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-        end
-        function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
-            statuscheck(ccall((:cublasDotcEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
-                                handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
-        end
-        function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
-            statuscheck(ccall((:cublasScalEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                                handle, n, alpha, alphaType, x, xType, incx, executionType));
-        end
-        function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
-            statuscheck(ccall((:cublasAxpyEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
-                                handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
-        end
-        function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCgemm3mEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-        end
-        function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasSgemmEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-        end
-        function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
-            statuscheck(ccall((:cublasGemmEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
-                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
-        end
-        function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCgemmEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
-        end
-        function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCsyrkEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-        end
-        function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-        end
-        function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCherkEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-        end
-        function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
-            statuscheck(ccall((:cublasCherk3mEx, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
-                                handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
-        end
-        # Wrap FP16 functions (CUDA 7.5+)
-        function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-            statuscheck(ccall((:cublasHgemm, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
-                                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
-        end
-        function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
-            statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
-                                cublasStatus_t,
-                                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
-                                handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
-        end
-    end
-catch exception
-    Base.show_backtrace(STDOUT, backtrace());
-    println();
+# Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
+function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
+    statuscheck(ccall((:cublasNrm2Ex, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, result, resultType, executionType));
+end
+function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+    statuscheck(ccall((:cublasDotEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+end
+function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+    statuscheck(ccall((:cublasDotcEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, cudaDataType_t),
+                        handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType));
+end
+function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
+    statuscheck(ccall((:cublasScalEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                        handle, n, alpha, alphaType, x, xType, incx, executionType));
+end
+function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
+    statuscheck(ccall((:cublasAxpyEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, Cint, Ptr{Void}, cudaDataType_t, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t),
+                        handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType));
+end
+function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCgemm3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasSgemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+    statuscheck(ccall((:cublasGemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Void}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{void}, Ptr{Void}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo));
+end
+function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCgemmEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc));
+end
+function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCsyrkEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCsyrk3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCherkEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
+    statuscheck(ccall((:cublasCherk3mEx, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Void}, cudaDataType_t, Cint),
+                        handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc));
+end
+# Wrap FP16 functions (CUDA 7.5+)
+function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    statuscheck(ccall((:cublasHgemm, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc));
+end
+function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+    statuscheck(ccall((:cublasHgemmStridedBatched, libcublas),
+                        cublasStatus_t,
+                        (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                        handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount));
 end

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -61,3 +61,36 @@ const cuDoubleComplex = Complex{Float64}
 const CublasFloat = Union{Float64,Float32,Complex128,Complex64}
 const CublasReal = Union{Float64,Float32}
 const CublasComplex = Union{Complex128,Complex64}
+# FP16 (cuda_fp16.h) in cuda
+const __half = Float16;
+immutable __half2
+    x1::__half
+    x2::__half
+end
+# specify which GEMM algorithm to use in cublasGemmEx() (CUDA 8+)
+const cublasGemmAlgo_t = UInt32;
+const CUBLAS_GEMM_DFALT = UInt32(-1);
+const CUBLAS_GEMM_ALGO0 = UInt32(0);
+const CUBLAS_GEMM_ALGO1 = UInt32(1);
+const CUBLAS_GEMM_ALGO2 = UInt32(2);
+const CUBLAS_GEMM_ALGO3 = UInt32(3);
+const CUBLAS_GEMM_ALGO4 = UInt32(4);
+const CUBLAS_GEMM_ALGO5 = UInt32(5);
+const CUBLAS_GEMM_ALGO6 = UInt32(6);
+const CUBLAS_GEMM_ALGO7 = UInt32(7);
+# specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 8+) functions
+const cudaDataType_t = UInt32;
+const CUDA_R_16F = UInt32(2);
+const CUDA_C_16F = UInt32(6);
+const CUDA_R_32F = UInt32(0);
+const CUDA_C_32F = UInt32(4);
+const CUDA_R_64F = UInt32(1);
+const CUDA_C_64F = UInt32(5);
+const CUDA_R_8I  = UInt32(3);
+const CUDA_C_8I  = UInt32(7);
+const CUDA_R_8U  = UInt32(8);
+const CUDA_C_8U  = UInt32(9);
+const CUDA_R_32I = UInt32(10);
+const CUDA_C_32I = UInt32(11);
+const CUDA_R_32U = UInt32(12);
+const CUDA_C_32U = UInt32(13);

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -67,38 +67,30 @@ immutable __half2
     x1::__half
     x2::__half
 end
-using CUDArt;
-try
-    if (CUDArt.runtime_version() >= 7500)
-        # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
-        const cublasGemmAlgo_t = Int32;
-        const CUBLAS_GEMM_DFALT = -1;
-        const CUBLAS_GEMM_ALGO0 = 0;
-        const CUBLAS_GEMM_ALGO1 = 1;
-        const CUBLAS_GEMM_ALGO2 = 2;
-        const CUBLAS_GEMM_ALGO3 = 3;
-        const CUBLAS_GEMM_ALGO4 = 4;
-        const CUBLAS_GEMM_ALGO5 = 5;
-        const CUBLAS_GEMM_ALGO6 = 6;
-        const CUBLAS_GEMM_ALGO7 = 7;
-        # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
-        const cudaDataType_t = UInt32;
-        const CUDA_R_16F = UInt32(2);
-        const CUDA_C_16F = UInt32(6);
-        const CUDA_R_32F = UInt32(0);
-        const CUDA_C_32F = UInt32(4);
-        const CUDA_R_64F = UInt32(1);
-        const CUDA_C_64F = UInt32(5);
-        const CUDA_R_8I  = UInt32(3);
-        const CUDA_C_8I  = UInt32(7);
-        const CUDA_R_8U  = UInt32(8);
-        const CUDA_C_8U  = UInt32(9);
-        const CUDA_R_32I = UInt32(10);
-        const CUDA_C_32I = UInt32(11);
-        const CUDA_R_32U = UInt32(12);
-        const CUDA_C_32U = UInt32(13);
-    end
-catch exception
-    Base.show_backtrace(STDOUT, backtrace());
-    println();
-end
+# specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
+const cublasGemmAlgo_t = Int32;
+const CUBLAS_GEMM_DFALT = -1;
+const CUBLAS_GEMM_ALGO0 = 0;
+const CUBLAS_GEMM_ALGO1 = 1;
+const CUBLAS_GEMM_ALGO2 = 2;
+const CUBLAS_GEMM_ALGO3 = 3;
+const CUBLAS_GEMM_ALGO4 = 4;
+const CUBLAS_GEMM_ALGO5 = 5;
+const CUBLAS_GEMM_ALGO6 = 6;
+const CUBLAS_GEMM_ALGO7 = 7;
+# specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
+const cudaDataType_t = UInt32;
+const CUDA_R_16F = UInt32(2);
+const CUDA_C_16F = UInt32(6);
+const CUDA_R_32F = UInt32(0);
+const CUDA_C_32F = UInt32(4);
+const CUDA_R_64F = UInt32(1);
+const CUDA_C_64F = UInt32(5);
+const CUDA_R_8I  = UInt32(3);
+const CUDA_C_8I  = UInt32(7);
+const CUDA_R_8U  = UInt32(8);
+const CUDA_C_8U  = UInt32(9);
+const CUDA_R_32I = UInt32(10);
+const CUDA_C_32I = UInt32(11);
+const CUDA_R_32U = UInt32(12);
+const CUDA_C_32U = UInt32(13);

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -67,30 +67,32 @@ immutable __half2
     x1::__half
     x2::__half
 end
-# specify which GEMM algorithm to use in cublasGemmEx() (CUDA 8+)
-const cublasGemmAlgo_t = Int32;
-const CUBLAS_GEMM_DFALT = -1;
-const CUBLAS_GEMM_ALGO0 = 0;
-const CUBLAS_GEMM_ALGO1 = 1;
-const CUBLAS_GEMM_ALGO2 = 2;
-const CUBLAS_GEMM_ALGO3 = 3;
-const CUBLAS_GEMM_ALGO4 = 4;
-const CUBLAS_GEMM_ALGO5 = 5;
-const CUBLAS_GEMM_ALGO6 = 6;
-const CUBLAS_GEMM_ALGO7 = 7;
-# specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 8+) functions
-const cudaDataType_t = UInt32;
-const CUDA_R_16F = UInt32(2);
-const CUDA_C_16F = UInt32(6);
-const CUDA_R_32F = UInt32(0);
-const CUDA_C_32F = UInt32(4);
-const CUDA_R_64F = UInt32(1);
-const CUDA_C_64F = UInt32(5);
-const CUDA_R_8I  = UInt32(3);
-const CUDA_C_8I  = UInt32(7);
-const CUDA_R_8U  = UInt32(8);
-const CUDA_C_8U  = UInt32(9);
-const CUDA_R_32I = UInt32(10);
-const CUDA_C_32I = UInt32(11);
-const CUDA_R_32U = UInt32(12);
-const CUDA_C_32U = UInt32(13);
+if (CUDArt.runtime_version() >= 7500)
+    # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
+    const cublasGemmAlgo_t = Int32;
+    const CUBLAS_GEMM_DFALT = -1;
+    const CUBLAS_GEMM_ALGO0 = 0;
+    const CUBLAS_GEMM_ALGO1 = 1;
+    const CUBLAS_GEMM_ALGO2 = 2;
+    const CUBLAS_GEMM_ALGO3 = 3;
+    const CUBLAS_GEMM_ALGO4 = 4;
+    const CUBLAS_GEMM_ALGO5 = 5;
+    const CUBLAS_GEMM_ALGO6 = 6;
+    const CUBLAS_GEMM_ALGO7 = 7;
+    # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
+    const cudaDataType_t = UInt32;
+    const CUDA_R_16F = UInt32(2);
+    const CUDA_C_16F = UInt32(6);
+    const CUDA_R_32F = UInt32(0);
+    const CUDA_C_32F = UInt32(4);
+    const CUDA_R_64F = UInt32(1);
+    const CUDA_C_64F = UInt32(5);
+    const CUDA_R_8I  = UInt32(3);
+    const CUDA_C_8I  = UInt32(7);
+    const CUDA_R_8U  = UInt32(8);
+    const CUDA_C_8U  = UInt32(9);
+    const CUDA_R_32I = UInt32(10);
+    const CUDA_C_32I = UInt32(11);
+    const CUDA_R_32U = UInt32(12);
+    const CUDA_C_32U = UInt32(13);
+end

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -67,32 +67,37 @@ immutable __half2
     x1::__half
     x2::__half
 end
-if (CUDArt.runtime_version() >= 7500)
-    # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
-    const cublasGemmAlgo_t = Int32;
-    const CUBLAS_GEMM_DFALT = -1;
-    const CUBLAS_GEMM_ALGO0 = 0;
-    const CUBLAS_GEMM_ALGO1 = 1;
-    const CUBLAS_GEMM_ALGO2 = 2;
-    const CUBLAS_GEMM_ALGO3 = 3;
-    const CUBLAS_GEMM_ALGO4 = 4;
-    const CUBLAS_GEMM_ALGO5 = 5;
-    const CUBLAS_GEMM_ALGO6 = 6;
-    const CUBLAS_GEMM_ALGO7 = 7;
-    # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
-    const cudaDataType_t = UInt32;
-    const CUDA_R_16F = UInt32(2);
-    const CUDA_C_16F = UInt32(6);
-    const CUDA_R_32F = UInt32(0);
-    const CUDA_C_32F = UInt32(4);
-    const CUDA_R_64F = UInt32(1);
-    const CUDA_C_64F = UInt32(5);
-    const CUDA_R_8I  = UInt32(3);
-    const CUDA_C_8I  = UInt32(7);
-    const CUDA_R_8U  = UInt32(8);
-    const CUDA_C_8U  = UInt32(9);
-    const CUDA_R_32I = UInt32(10);
-    const CUDA_C_32I = UInt32(11);
-    const CUDA_R_32U = UInt32(12);
-    const CUDA_C_32U = UInt32(13);
+try
+    if (CUDArt.runtime_version() >= 7500)
+        # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
+        const cublasGemmAlgo_t = Int32;
+        const CUBLAS_GEMM_DFALT = -1;
+        const CUBLAS_GEMM_ALGO0 = 0;
+        const CUBLAS_GEMM_ALGO1 = 1;
+        const CUBLAS_GEMM_ALGO2 = 2;
+        const CUBLAS_GEMM_ALGO3 = 3;
+        const CUBLAS_GEMM_ALGO4 = 4;
+        const CUBLAS_GEMM_ALGO5 = 5;
+        const CUBLAS_GEMM_ALGO6 = 6;
+        const CUBLAS_GEMM_ALGO7 = 7;
+        # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
+        const cudaDataType_t = UInt32;
+        const CUDA_R_16F = UInt32(2);
+        const CUDA_C_16F = UInt32(6);
+        const CUDA_R_32F = UInt32(0);
+        const CUDA_C_32F = UInt32(4);
+        const CUDA_R_64F = UInt32(1);
+        const CUDA_C_64F = UInt32(5);
+        const CUDA_R_8I  = UInt32(3);
+        const CUDA_C_8I  = UInt32(7);
+        const CUDA_R_8U  = UInt32(8);
+        const CUDA_C_8U  = UInt32(9);
+        const CUDA_R_32I = UInt32(10);
+        const CUDA_C_32I = UInt32(11);
+        const CUDA_R_32U = UInt32(12);
+        const CUDA_C_32U = UInt32(13);
+    end
+catch exception
+    Base.show_backtrace(STDOUT, backtrace());
+    println();
 end

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -67,30 +67,37 @@ immutable __half2
     x1::__half
     x2::__half
 end
-# specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
-const cublasGemmAlgo_t = Int32;
-const CUBLAS_GEMM_DFALT = -1;
-const CUBLAS_GEMM_ALGO0 = 0;
-const CUBLAS_GEMM_ALGO1 = 1;
-const CUBLAS_GEMM_ALGO2 = 2;
-const CUBLAS_GEMM_ALGO3 = 3;
-const CUBLAS_GEMM_ALGO4 = 4;
-const CUBLAS_GEMM_ALGO5 = 5;
-const CUBLAS_GEMM_ALGO6 = 6;
-const CUBLAS_GEMM_ALGO7 = 7;
-# specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
-const cudaDataType_t = UInt32;
-const CUDA_R_16F = UInt32(2);
-const CUDA_C_16F = UInt32(6);
-const CUDA_R_32F = UInt32(0);
-const CUDA_C_32F = UInt32(4);
-const CUDA_R_64F = UInt32(1);
-const CUDA_C_64F = UInt32(5);
-const CUDA_R_8I  = UInt32(3);
-const CUDA_C_8I  = UInt32(7);
-const CUDA_R_8U  = UInt32(8);
-const CUDA_C_8U  = UInt32(9);
-const CUDA_R_32I = UInt32(10);
-const CUDA_C_32I = UInt32(11);
-const CUDA_R_32U = UInt32(12);
-const CUDA_C_32U = UInt32(13);
+try
+    if (CUDArt.runtime_version() >= 7500)
+        # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)
+        const cublasGemmAlgo_t = Int32;
+        const CUBLAS_GEMM_DFALT = -1;
+        const CUBLAS_GEMM_ALGO0 = 0;
+        const CUBLAS_GEMM_ALGO1 = 1;
+        const CUBLAS_GEMM_ALGO2 = 2;
+        const CUBLAS_GEMM_ALGO3 = 3;
+        const CUBLAS_GEMM_ALGO4 = 4;
+        const CUBLAS_GEMM_ALGO5 = 5;
+        const CUBLAS_GEMM_ALGO6 = 6;
+        const CUBLAS_GEMM_ALGO7 = 7;
+        # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 7.5+) functions
+        const cudaDataType_t = UInt32;
+        const CUDA_R_16F = UInt32(2);
+        const CUDA_C_16F = UInt32(6);
+        const CUDA_R_32F = UInt32(0);
+        const CUDA_C_32F = UInt32(4);
+        const CUDA_R_64F = UInt32(1);
+        const CUDA_C_64F = UInt32(5);
+        const CUDA_R_8I  = UInt32(3);
+        const CUDA_C_8I  = UInt32(7);
+        const CUDA_R_8U  = UInt32(8);
+        const CUDA_C_8U  = UInt32(9);
+        const CUDA_R_32I = UInt32(10);
+        const CUDA_C_32I = UInt32(11);
+        const CUDA_R_32U = UInt32(12);
+        const CUDA_C_32U = UInt32(13);
+    end
+catch exception
+    Base.show_backtrace(STDOUT, backtrace());
+    println();
+end

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -68,16 +68,16 @@ immutable __half2
     x2::__half
 end
 # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 8+)
-const cublasGemmAlgo_t = UInt32;
-const CUBLAS_GEMM_DFALT = UInt32(-1);
-const CUBLAS_GEMM_ALGO0 = UInt32(0);
-const CUBLAS_GEMM_ALGO1 = UInt32(1);
-const CUBLAS_GEMM_ALGO2 = UInt32(2);
-const CUBLAS_GEMM_ALGO3 = UInt32(3);
-const CUBLAS_GEMM_ALGO4 = UInt32(4);
-const CUBLAS_GEMM_ALGO5 = UInt32(5);
-const CUBLAS_GEMM_ALGO6 = UInt32(6);
-const CUBLAS_GEMM_ALGO7 = UInt32(7);
+const cublasGemmAlgo_t = Int32;
+const CUBLAS_GEMM_DFALT = -1;
+const CUBLAS_GEMM_ALGO0 = 0;
+const CUBLAS_GEMM_ALGO1 = 1;
+const CUBLAS_GEMM_ALGO2 = 2;
+const CUBLAS_GEMM_ALGO3 = 3;
+const CUBLAS_GEMM_ALGO4 = 4;
+const CUBLAS_GEMM_ALGO5 = 5;
+const CUBLAS_GEMM_ALGO6 = 6;
+const CUBLAS_GEMM_ALGO7 = 7;
 # specify which DataType to use with cublas<t>gemmEx() and cublasGemmEx() (CUDA 8+) functions
 const cudaDataType_t = UInt32;
 const CUDA_R_16F = UInt32(2);

--- a/src/libcublas_types.jl
+++ b/src/libcublas_types.jl
@@ -67,6 +67,7 @@ immutable __half2
     x1::__half
     x2::__half
 end
+using CUDArt;
 try
     if (CUDArt.runtime_version() >= 7500)
         # specify which GEMM algorithm to use in cublasGemmEx() (CUDA 7.5+)


### PR DESCRIPTION
I have written these wrapper functions to be defined if the CUDA runtime version is 7.5+.

I would like to submit these to the project.

Since this module is precompiled based on other unstable changes in the respective CUDA wrapper libraries (CUDAdrv and CUDArt), I manually removed existing compilecaches of CUDAdrv.jl, CUDArt.jl, and CUBLAS.jl during testing.